### PR TITLE
Updated Notifications setup

### DIFF
--- a/mobi/src/main/java/com/mobiperf/MeasurementScheduler.java
+++ b/mobi/src/main/java/com/mobiperf/MeasurementScheduler.java
@@ -84,7 +84,7 @@ public class MeasurementScheduler extends Service {
 
   // This arbitrary id is private to Speedometer
   private static final int NOTIFICATION_ID = 1234;
-  private static final String CHANNEL_ID = "";
+  private static final String CHANNEL_ID = "speedometer_01";
 
   private ExecutorService measurementExecutor;
   private BroadcastReceiver broadcastReceiver;

--- a/mobi/src/main/res/values/strings.xml
+++ b/mobi/src/main/res/values/strings.xml
@@ -58,6 +58,8 @@
     <string name="defaultUser">Anonymous</string>
     <string name="TCPThroughputDirLabel">Direction:</string>
     <string name="TCPThroughputTargetHint">m-lab</string>
-    
-    
+    <string name="channel_name">Speedometer Category</string>
+    <string name="channel_description" />
+
+
 </resources>


### PR DESCRIPTION
Changed from using the old deprecated style of building notifications to using the new one. 
 This required also the addition of Notification Channels which needed to be created before the notifications can be shown. This was created also and added as a method that was called as soon as the app started.