### PR TITLE
changed measurement TYPE string attribute to inject uniformity

### DIFF
--- a/mobi/src/main/java/com/mobiperf/measurements/DnsLookupTask.java
+++ b/mobi/src/main/java/com/mobiperf/measurements/DnsLookupTask.java
@@ -38,7 +38,7 @@ import java.util.Map;
  */
 public class DnsLookupTask extends MeasurementTask {
   // Type name for internal use
-  public static final String TYPE = "dns_lookup";
+  public static final String TYPE = "DNS_LOOKUP";
   // Human readable name for the task
   public static final String DESCRIPTOR = "DNS lookup";
   

--- a/mobi/src/main/java/com/mobiperf/measurements/HttpTask.java
+++ b/mobi/src/main/java/com/mobiperf/measurements/HttpTask.java
@@ -53,7 +53,7 @@ import java.util.Map;
  */
 public class HttpTask extends MeasurementTask {
   // Type name for internal use
-  public static final String TYPE = "http";
+  public static final String TYPE = "HTTP";
   // Human readable name for the task
   public static final String DESCRIPTOR = "HTTP";
   /* TODO(Wenjie): Depending on state machine configuration of cell tower's radio,

--- a/mobi/src/main/java/com/mobiperf/measurements/PingTask.java
+++ b/mobi/src/main/java/com/mobiperf/measurements/PingTask.java
@@ -58,7 +58,7 @@ import com.mobiperf.SpeedometerApp;
  */
 public class PingTask extends MeasurementTask {
   // Type name for internal use
-  public static final String TYPE = "ping";
+  public static final String TYPE = "PING";
   // Human readable name for the task
   public static final String DESCRIPTOR = "ping";
   /* Default payload size of the ICMP packet, plus the 8-byte ICMP header resulting in a total of 

--- a/mobi/src/main/java/com/mobiperf/measurements/RRCTask.java
+++ b/mobi/src/main/java/com/mobiperf/measurements/RRCTask.java
@@ -77,7 +77,7 @@ import com.mobiperf.util.Util;
  */
 public class RRCTask extends MeasurementTask {
   // Type name for internal use
-  public static final String TYPE = "rrc";
+  public static final String TYPE = "RRC";
   // Human readable name for the task
   public static final String DESCRIPTOR = "rrc";
   public static String TAG = "MobiPerf_RRC_INFERENCE";

--- a/mobi/src/main/java/com/mobiperf/measurements/TCPThroughputTask.java
+++ b/mobi/src/main/java/com/mobiperf/measurements/TCPThroughputTask.java
@@ -46,7 +46,7 @@ public class TCPThroughputTask extends MeasurementTask {
   public static final int PORT_DOWNLINK = 6001;
   public static final int PORT_UPLINK = 6002;
   public static final int PORT_CONFIG = 6003;
-  public static final String TYPE = "tcpthroughput";
+  public static final String TYPE = "TCP_SPEED_TEST";
 
   // Timing related
   public final int BUFFER_SIZE = 5000;

--- a/mobi/src/main/java/com/mobiperf/measurements/TracerouteTask.java
+++ b/mobi/src/main/java/com/mobiperf/measurements/TracerouteTask.java
@@ -45,7 +45,7 @@ import com.mobiperf.MeasurementTask;
  */
 public class TracerouteTask extends MeasurementTask {
   // Type name for internal use
-  public static final String TYPE = "traceroute";
+  public static final String TYPE = "TRACEROUTE";
   // Human readable name for the task
   public static final String DESCRIPTOR = "traceroute";
   /* Default payload size of the ICMP packet, plus the 8-byte ICMP header resulting in a total of 

--- a/mobi/src/main/java/com/mobiperf/measurements/UDPBurstTask.java
+++ b/mobi/src/main/java/com/mobiperf/measurements/UDPBurstTask.java
@@ -52,7 +52,7 @@ import java.util.Map;
  * of each packet is packetSizeByte
  */
 public class UDPBurstTask extends MeasurementTask {
-  public static final String TYPE = "udp_burst";
+  public static final String TYPE = "UDP_BURST";
   public static final String DESCRIPTOR = "UDP Burst";
   
   private static final int DEFAULT_PORT = 31341;


### PR DESCRIPTION
Changed the TYPE field on the different measurements to make the naming scheme standard across different measurements perfomed